### PR TITLE
stage2: catch exceptions reading jar metadata

### DIFF
--- a/stage2/common/src/main/java/gg/essential/loader/stage2/EssentialLoaderBase.java
+++ b/stage2/common/src/main/java/gg/essential/loader/stage2/EssentialLoaderBase.java
@@ -116,7 +116,11 @@ public abstract class EssentialLoaderBase {
         // Load current metadata from existing jar (if one exists)
         ModJarMetadata currentMeta = ModJarMetadata.EMPTY;
         if (Files.exists(essentialFile)) {
-            currentMeta = ModJarMetadata.read(essentialFile);
+            try {
+                currentMeta = ModJarMetadata.read(essentialFile);
+            } catch (IOException e) {
+                LOGGER.warn("Failed to read existing Essential jar metadata", e);
+            }
         }
         String currentChecksum = currentMeta.getChecksum();
 


### PR DESCRIPTION
fixes crashes caused by a corrupted Essential jar