### PR TITLE
stage2/fabric: Support for fabric-loader 0.16.1

### DIFF
--- a/stage2/fabric/src/main/java/gg/essential/loader/stage2/EssentialLoader.java
+++ b/stage2/fabric/src/main/java/gg/essential/loader/stage2/EssentialLoader.java
@@ -262,7 +262,14 @@ public class EssentialLoader extends EssentialLoaderBase {
 
         @SuppressWarnings("UnstableApiUsage")
         public void remapMod(ModMetadata metadata, Path inputPath, Path outputPath) throws Exception {
-            Class<?> ModCandidate = findImplClass("discovery.ModCandidate");
+            Class<?> ModCandidate;
+            try {
+                // fabric-loader 0.16.1
+                ModCandidate = findImplClass("discovery.ModCandidateImpl");
+            } catch (ClassNotFoundException e) {
+                // fabric-loader 0.16.0
+                ModCandidate = findImplClass("discovery.ModCandidate");
+            }
             Class<?> ModResolver = findImplClass("discovery.ModResolver");
             Class<?> RuntimeModRemapper = findImplClass("discovery.RuntimeModRemapper");
 
@@ -313,7 +320,14 @@ public class EssentialLoader extends EssentialLoaderBase {
 
         private Object createCandidate(Path path, URL url, Object metadata) throws ClassNotFoundException, InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
             Class<?> LoaderModMetadata = findImplClass("metadata.LoaderModMetadata");
-            Class<?> ModCandidate = findImplClass("discovery.ModCandidate");
+            Class<?> ModCandidate;
+            try {
+                // fabric-loader 0.16.1
+                ModCandidate = findImplClass("discovery.ModCandidateImpl");
+            } catch (ClassNotFoundException e) {
+                // fabric-loader 0.16.0
+                ModCandidate = findImplClass("discovery.ModCandidate");
+            }
             try {
                 // fabric loader 0.11
                 return ModCandidate.getConstructor(LoaderModMetadata, URL.class, int.class, boolean.class)
@@ -384,9 +398,10 @@ public class EssentialLoader extends EssentialLoaderBase {
                         .newInstance(metadata, path);
                 } catch (NoSuchMethodException e1) {
                     // fabric-loader 0.13
+                    Object modCandidate = createCandidate(path, url, metadata);
                     modContainer = ModContainerImpl
-                        .getConstructor(findImplClass("discovery.ModCandidate"))
-                        .newInstance(createCandidate(path, url, metadata));
+                        .getConstructor(modCandidate.getClass())
+                        .newInstance(modCandidate);
                 }
             }
             mods.add(modContainer);


### PR DESCRIPTION
ModCandidate was renamed to ModCandidateImpl:
https://github.com/FabricMC/fabric-loader/commit/da94132186efa61d6ebe8e584e6ca5bb6c8d18bb

remapMod appears to still be broken due to a separate preexisting issue, but since it is only required for dev environments, this can be fixed later.

Linear: EM-2887