### PR TITLE
stage2/ml9: Support KotlinForForge 5.8

### DIFF
--- a/stage2/modlauncher9/build.gradle
+++ b/stage2/modlauncher9/build.gradle
@@ -22,4 +22,5 @@ dependencies {
     // provided by fmlloader (both forge and neoforge ones)
     compileOnly("org.apache.logging.log4j:log4j-api:2.8.1")
     compileOnly("org.apache.maven:maven-artifact:3.8.1")
+    compileOnly("com.google.code.gson:gson:2.8.0")
 }


### PR DESCRIPTION
KFF 5.8 switched to using a different JarJar gradle plugin which assigns a different file name to the nested `kffmod` jar, resulting in our `isJarJarKff` failing to identify it.

This commit fixes the issue by properly parsing the JarJar `metadata.json` file instead of matching file names.